### PR TITLE
Fix link error & allow for alternative compilers

### DIFF
--- a/bpi_test/Makefile
+++ b/bpi_test/Makefile
@@ -25,7 +25,7 @@
 
 #DEBUG	= -g -O0
 DEBUG	= -O3
-CC	= gcc
+CC	?= gcc
 INCLUDE	= -I/usr/local/include
 INCLUDE	+= -I/usr/include
 CFLAGS	= $(DEBUG) -Wall $(INCLUDE) -Winline -pipe

--- a/devLib/Makefile
+++ b/devLib/Makefile
@@ -36,7 +36,7 @@ DYNAMIC=libwiringPiDev.so.$(VERSION)
 
 #DEBUG	= -g -O0
 DEBUG	= -O2
-CC	= gcc
+CC	?= gcc
 INCLUDE	= -I.
 DEFS	= -D_GNU_SOURCE
 CFLAGS	= $(DEBUG) $(DEFS) -Wformat=2 -Wall -Winline $(INCLUDE) -pipe -fPIC

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -28,7 +28,7 @@ endif
 
 #DEBUG	= -g -O0
 DEBUG	= -O3
-CC	= gcc
+CC	?= gcc
 INCLUDE	= -I/usr/local/include
 CFLAGS	= $(DEBUG) -Wall $(INCLUDE) -Winline -pipe
 

--- a/gpio/Makefile
+++ b/gpio/Makefile
@@ -32,7 +32,7 @@ endif
 
 #DEBUG	= -g -O0
 DEBUG	= -O2
-CC	= gcc
+CC	?= gcc
 INCLUDE	= -I$(DESTDIR)$(PREFIX)/include
 CFLAGS	= $(DEBUG) -Wall -Wextra $(INCLUDE) -Winline -pipe
 

--- a/wiringPi/Makefile
+++ b/wiringPi/Makefile
@@ -36,7 +36,7 @@ DYNAMIC=libwiringPi.so.$(VERSION)
 
 #DEBUG	= -g -O0
 DEBUG	= -O2
-CC	= gcc
+CC	?= gcc
 INCLUDE	= -I. -I./board
 DEFS	= -D_GNU_SOURCE
 CFLAGS	= $(DEBUG) $(DEFS) -Wformat=2 -Wall -Wextra -Winline $(INCLUDE) -pipe -fPIC

--- a/wiringPiD/Makefile
+++ b/wiringPiD/Makefile
@@ -31,7 +31,7 @@ endif
 
 #DEBUG	= -g -O0
 DEBUG	= -O2
-CC	= gcc
+CC	?= gcc
 INCLUDE	= -I$(DESTDIR)$(PREFIX)/include
 CFLAGS	= $(DEBUG) -Wall -Wextra $(INCLUDE) -Winline -pipe
 

--- a/wiringPiD/drcNetCmd.h
+++ b/wiringPiD/drcNetCmd.h
@@ -19,6 +19,8 @@
  *    along with wiringPi.  If not, see <http://www.gnu.org/licenses/>.
  ***********************************************************************
  */
+#pragma once
+
 
 #define	DEFAULT_SERVER_PORT	6124
 
@@ -35,7 +37,7 @@
 #define	DRCN_ANALOG_READ	9
 
 
-struct drcNetComStruct
+typedef struct drcNetComStruct
 {
   uint32_t pin ;
   uint32_t cmd ;


### PR DESCRIPTION
Fix link errors for newer compilers/OS (see https://github.com/orangepi-xunlong/wiringOP/issues/35). Also allow for CC override.